### PR TITLE
Set auto_inactive

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -69,6 +69,7 @@ jobs:
           log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           mediaType: '{"previews": ["ant-man"]}'
           state: success
+          auto_inactive: false
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 


### PR DESCRIPTION
This will keep existing review deploys active when a new deploy has succeeded.